### PR TITLE
Add abortpipe() to timeout on read

### DIFF
--- a/python/USB_FTX232H_FT60X.py
+++ b/python/USB_FTX232H_FT60X.py
@@ -3,6 +3,7 @@
 
 
 import sys
+from ftd3xx.defines import *
 
 
 
@@ -236,6 +237,10 @@ class USB_FTX232H_FT60X_sync245mode():
                 ei = min(ei, recv_len)
                 
                 rxlen_once = self._usb.readPipe(0x82, chunk, ei-si)      # try to read (ei-si) bytes
+                usb_status = self._usb.getLastError()
+                if usb_status == FT_TIMEOUT:
+                    print('read timeout. aborting pipe.')
+                    self._usb.abortPipe(0x82)
                 
                 si += rxlen_once
                 


### PR DESCRIPTION
The D3XX DLL seems to freeze when calling readPipe() after having already called readPipe() with return status timeout error.
The timeout happens because usb_loopback_simple.py attempts to receive twice as many bytes as are sent.
`data = usb.recv(txlen*2)`

![image](https://github.com/WangXuan95/FPGA-ftdi245fifo/assets/16520440/c77ece30-601d-49fc-be24-0ebea335fb96)

Reference page 9: https://ftdichip.com/wp-content/uploads/2020/08/AN_412_FT600_FT601-USB-Bridge-chips-Integration.pdf

Thank you for this very helpful project!
